### PR TITLE
fix(driver): usage of "/" as root path

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@
 
 Mangled Deutz <olivier@webitup.fr>
 Matthew Fisher <matthewf@opdemand.com>
+Vincent Giersch <vincent@giersch.fr>

--- a/tests/test.py
+++ b/tests/test.py
@@ -32,3 +32,28 @@ class TestDriver(testing.Driver):
     # swiftclient doesn't raise if what we remove doesn't exist, which is bad!
     def test_remove_inexistent(self):
         pass
+
+    def test_list_directory(self):
+        # Test with root directory
+        super(TestDriver, self).test_list_directory()
+        self.tearDown()
+
+        # Test with custom root directory
+        self._storage.__init__(config={'storage_path': '/foo'})
+        self.setUp()
+        super(TestDriver, self).test_list_directory()
+
+    def test_swift_root_path_default(self):
+        assert self._storage._root_path == '/'
+        assert self._storage._init_path() == ''
+        assert self._storage._init_path('foo') == 'foo'
+
+    def test_swift_root_path_empty(self):
+        self._storage.__init__(config={'storage_path': ''})
+        assert self._storage._init_path() == ''
+        assert self._storage._init_path('foo') == 'foo'
+
+    def test_swift_root_path_custom(self):
+        self._storage.__init__(config={'storage_path': '/foo'})
+        assert self._storage._init_path() == 'foo'
+        assert self._storage._init_path('foo') == 'foo/foo'


### PR DESCRIPTION
- Generated a "//" in storage urls
- Truncated the first "/" when listing directory
