### PR TITLE
fix(driver): trailing slash with custom root path

### DIFF
--- a/docker_registry/drivers/swift.py
+++ b/docker_registry/drivers/swift.py
@@ -102,7 +102,7 @@ class Storage(driver.Base):
                     inode['name'] = inode['name'][:-1]
                 if self._root_path != '/':
                     inode['name'] = inode['name'].replace(
-                        self._init_path(), '', 1)
+                        self._init_path() + '/', '', 1)
                 yield inode['name']
         except Exception:
             raise exceptions.FileNotFoundError('%s is not there' % path)

--- a/tests/test.py
+++ b/tests/test.py
@@ -39,7 +39,7 @@ class TestDriver(testing.Driver):
         self.tearDown()
 
         # Test with custom root directory
-        self._storage.__init__(config={'storage_path': '/foo'})
+        self.config = testing.Config({'storage_path': '/foo'})
         self.setUp()
         super(TestDriver, self).test_list_directory()
 


### PR DESCRIPTION
It fixes bacongobbler/docker-registry-driver-swift#8 @mbdas issue
