### PR TITLE
fix(driver): Compatibility with the registry 0.8

### DIFF
--- a/docker_registry/drivers/swift.py
+++ b/docker_registry/drivers/swift.py
@@ -9,21 +9,22 @@ class Storage(driver.Base):
 
     def __init__(self, path=None, config=None):
         self._swift_connection = self._create_swift_connection(config)
-        self._swift_container = config.get('swift_container', 'dev_container')
-        self._root_path = config.get('storage_path', '/')
+        self._swift_container = config.swift_container or 'dev_container'
+        self._root_path = config.storage_path or '/'
         if not self._root_path.endswith('/'):
             self._root_path += '/'
 
     def _create_swift_connection(self, config):
+        swift_auth_version = config.swift_auth_version or 2
         return swiftclient.client.Connection(
-            authurl=config.get('swift_authurl'),
-            user=config.get('swift_user'),
-            key=config.get('swift_password'),
-            auth_version=config.get('swift_auth_version', 2),
+            authurl=config.swift_authurl,
+            user=config.swift_user,
+            key=config.swift_password,
+            auth_version=swift_auth_version,
             os_options={
-                'tenant_name': config.get('swift_tenant_name'),
-                'region_name': config.get('swift_region_name'),
-                'object_storage_url': config.get('swift_object_storage_url')
+                'tenant_name': config.swift_tenant_name,
+                'region_name': config.swift_region_name,
+                'object_storage_url': config.swift_object_storage_url
             })
 
     def _init_path(self, path=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-docker-registry-core>=1,<2
+docker-registry-core>=2,<3
 python-keystoneclient==0.10.0
 python-swiftclient==2.2.0

--- a/tests/test.py
+++ b/tests/test.py
@@ -49,11 +49,13 @@ class TestDriver(testing.Driver):
         assert self._storage._init_path('foo') == 'foo'
 
     def test_swift_root_path_empty(self):
-        self._storage.__init__(config={'storage_path': ''})
+        config = testing.Config({'storage_path': ''})
+        self._storage.__init__(config=config)
         assert self._storage._init_path() == ''
         assert self._storage._init_path('foo') == 'foo'
 
     def test_swift_root_path_custom(self):
-        self._storage.__init__(config={'storage_path': '/foo'})
+        config = testing.Config({'storage_path': '/foo'})
+        self._storage.__init__(config=config)
         assert self._storage._init_path() == 'foo'
         assert self._storage._init_path('foo') == 'foo/foo'


### PR DESCRIPTION
The docker-registry-core >= 2.0.0 (docker-registry >= 0.8) breaks the
compatibility with the config usage (docker/docker-registry#444)

This commit fixes bacongobbler/docker-registry-driver-swift#12
