### PR TITLE
Add OS_CACERT support for better private OpenStack cloud support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ You may add any of the following to your main docker-registry configuration to f
 storage: swift
 storage_path: /registry
 swift_authurl: _env:OS_AUTH_URL
+swift_cacert: _env:OS_CACERT
 swift_container: _env:OS_CONTAINER
 swift_user: _env:OS_USERNAME
 swift_password: _env:OS_PASSWORD

--- a/docker_registry/drivers/swift.py
+++ b/docker_registry/drivers/swift.py
@@ -18,6 +18,7 @@ class Storage(driver.Base):
         swift_auth_version = config.swift_auth_version or 2
         return swiftclient.client.Connection(
             authurl=config.swift_authurl,
+            cacert=config.swift_cacert,
             user=config.swift_user,
             key=config.swift_password,
             auth_version=swift_auth_version,


### PR DESCRIPTION
We're using this very minor patch in order to utilize an OpenStack Swift private cloud deployment that has self-signed certificates.  Not sure if you consider this a bugfix or a feature, it's just a passthrough of OS_CACERT per normal swiftclient usage.